### PR TITLE
update to bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/Zeenobit/moonshine_util"
 
 [dependencies]
 disqualified = "1.*"
-bevy_ecs = "0.15.*"
-bevy_hierarchy = "0.15.*"
+bevy_ecs = "0.16.*"
 
 [dev-dependencies]
-bevy = "0.15.*"
+bevy = "0.16.*"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fn find_needle(
     needle_query: Query<Entity, With<Needle>>,
     hierarchy: HierarchyQuery
 ) {
-    let haystack = haystack.single();
+    let haystack = haystack.single().unwrap();
     for needle in hierarchy.descendants_deep(haystack) {
         // ...
     }

--- a/src/expect.rs
+++ b/src/expect.rs
@@ -111,7 +111,7 @@ impl<T: Component> Component for Expect<T> {
     fn register_component_hooks(hooks: &mut ComponentHooks) {
         hooks.on_add(Self::on_add);
     }
-    
+
     type Mutability = Mutable;
 }
 
@@ -138,15 +138,15 @@ impl<T: WorldQuery> Clone for ExpectFetch<'_, T> {
 
 unsafe impl<T: QueryData> QueryData for Expect<T> {
     type ReadOnly = Expect<T::ReadOnly>;
-    
+
     const IS_READ_ONLY: bool = false;
-    
+
     type Item<'w> = T::Item<'w>;
-    
+
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         T::shrink(item)
     }
-    
+
     #[inline(always)]
     unsafe fn fetch<'w>(
         fetch: &mut Self::Fetch<'w>,
@@ -173,8 +173,6 @@ unsafe impl<T: ReadOnlyQueryData> ReadOnlyQueryData for Expect<T> {}
 unsafe impl<T: QueryData> WorldQuery for Expect<T> {
     type Fetch<'w> = ExpectFetch<'w, T>;
     type State = T::State;
-
-
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         ExpectFetch {

--- a/src/future.rs
+++ b/src/future.rs
@@ -214,30 +214,30 @@ mod test {
         w.spawn(Client(f));
 
         assert_eq!(
-            w.run_system_once(move |q: Query<&Client>| { q.single().0.poll() })
+            w.run_system_once(move |q: Query<&Client>| { q.single().unwrap().0.poll() })
                 .unwrap(),
             Wait
         );
         assert_eq!(
-            w.run_system_once(move |q: Query<&Client>| { q.single().0.poll() })
+            w.run_system_once(move |q: Query<&Client>| { q.single().unwrap().0.poll() })
                 .unwrap(),
             Wait
         );
 
         w.run_system_once(move |q: Query<(Entity, &Server)>, mut commands: Commands| {
-            let (entity, server) = q.single();
+            let (entity, server) = q.single().unwrap();
             server.0.set(());
             commands.entity(entity).remove::<Server>();
         })
         .unwrap();
 
         assert_eq!(
-            w.run_system_once(move |q: Query<&Client>| { q.single().0.poll() })
+            w.run_system_once(move |q: Query<&Client>| { q.single().unwrap().0.poll() })
                 .unwrap(),
             Ready(())
         );
         assert_eq!(
-            w.run_system_once(move |q: Query<&Client>| { q.single().0.poll() })
+            w.run_system_once(move |q: Query<&Client>| { q.single().unwrap().0.poll() })
                 .unwrap(),
             Expired
         );

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,17 +1,16 @@
 use bevy_ecs::{prelude::*, system::SystemParam};
-use bevy_hierarchy::prelude::*;
 
 /// A [`SystemParam`] for ergonomic [`Entity`] hierarchy traversal.
 #[derive(SystemParam)]
 pub struct HierarchyQuery<'w, 's> {
-    parent: Query<'w, 's, &'static Parent>,
+    parent: Query<'w, 's, &'static ChildOf>,
     children: Query<'w, 's, &'static Children>,
 }
 
 impl HierarchyQuery<'_, '_> {
     /// Returns the parent of the given entity, if it has one.
     pub fn parent(&self, entity: Entity) -> Option<Entity> {
-        self.parent.get(entity).ok().map(|parent| **parent)
+        self.parent.get(entity).ok().map(|parent| parent.0)
     }
 
     /// Iterates over the children of the given entity.
@@ -88,7 +87,7 @@ mod tests {
         let r = w
             .run_system_once(
                 move |q: HierarchyQuery, qa: Query<&A>, qx: Query<Entity, With<X>>| {
-                    let entity = qx.single();
+                    let entity = qx.single().unwrap();
                     let mut r = Vec::new();
                     for e in q.ancestors(entity) {
                         r.push(qa.get(e).unwrap().0);

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,8 +20,6 @@ unsafe impl<T: FromQuery> WorldQuery for Get<T> {
 
     type State = <T::Query as WorldQuery>::State;
 
-
-
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         T::Query::shrink_fetch(fetch)
     }
@@ -72,15 +70,15 @@ unsafe impl<T: FromQuery> WorldQuery for Get<T> {
 
 unsafe impl<T: FromQuery> QueryData for Get<T> {
     type ReadOnly = Self;
-    
+
     const IS_READ_ONLY: bool = false;
-    
+
     type Item<'a> = T;
-    
+
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item
     }
-    
+
     unsafe fn fetch<'w>(
         fetch: &mut Self::Fetch<'w>,
         entity: Entity,

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,22 +9,18 @@ use bevy_ecs::storage::{Table, TableRow};
 pub trait FromQuery {
     type Query: ReadOnlyQueryData;
 
-    fn map(data: <Self::Query as WorldQuery>::Item<'_>) -> Self;
+    fn map(data: <Self::Query as QueryData>::Item<'_>) -> Self;
 }
 
 // TODO: Documentation (Experimental!)
 pub struct Get<T>(PhantomData<T>);
 
 unsafe impl<T: FromQuery> WorldQuery for Get<T> {
-    type Item<'a> = T;
-
     type Fetch<'a> = <T::Query as WorldQuery>::Fetch<'a>;
 
     type State = <T::Query as WorldQuery>::State;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
+
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         T::Query::shrink_fetch(fetch)
@@ -54,14 +50,6 @@ unsafe impl<T: FromQuery> WorldQuery for Get<T> {
         unsafe { T::Query::set_table(fetch, state, table) }
     }
 
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Self::Item<'w> {
-        T::map(T::Query::fetch(fetch, entity, table_row))
-    }
-
     fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
         T::Query::update_component_access(state, access)
     }
@@ -84,6 +72,22 @@ unsafe impl<T: FromQuery> WorldQuery for Get<T> {
 
 unsafe impl<T: FromQuery> QueryData for Get<T> {
     type ReadOnly = Self;
+    
+    const IS_READ_ONLY: bool = false;
+    
+    type Item<'a> = T;
+    
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+    
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        T::map(T::Query::fetch(fetch, entity, table_row))
+    }
 }
 
 unsafe impl<T: FromQuery> ReadOnlyQueryData for Get<T> {}


### PR DESCRIPTION
I need moonshine_save in 0.16, moonshine_save needs this, so here is a 0.16 update pr.

Everything here should now be updated.

cargo test passes

`.single()` instances now use `.single().unwrap()` for expediency and because that's their equivalent 0.15 behavior. 